### PR TITLE
Consume only valid keypresses

### DIFF
--- a/Source/PluginEditor.cpp
+++ b/Source/PluginEditor.cpp
@@ -210,9 +210,11 @@ bool AbcomparisonAudioProcessorEditor::keyPressed (const KeyPress &key, Componen
     auto choice = key.getKeyCode() - 49;
     if (choice == - 1)
         choice = 9;
-    if (choice >= 0 && choice < jmin (nChoices, 10))
+    if (choice >= 0 && choice < jmin (nChoices, 10)) {
         tbChoice.getUnchecked (choice)->triggerClick();
-    return true;
+        return true;
+    }
+    return false;
 }
 
 void AbcomparisonAudioProcessorEditor::updateNumberOfButtons()


### PR DESCRIPTION
This way other keypresses are forwarded to the plugin host. In practice,
you can keep the ABComparison UI active and you can press space to
play/pause and use the number keys to change the input source.